### PR TITLE
Fixed Type error

### DIFF
--- a/lib/driver_constants.js
+++ b/lib/driver_constants.js
@@ -646,14 +646,14 @@ exports.LJM_LIBRARY_BASE_NAME = {
 exports.LJM_LIBRARY_NAME = exports.LJM_LIBRARY_BASE_NAME + exports.LJM_LIBRARY_FILE_TYPE;
 
 let defaultLinuxLibraryLocsToSearch = {
-    // 'ia32': function() {return ['/usr/local/lib'];},
-    // 'x64': function() {return ['/usr/local/lib'];},
-    // 'arm': function() {return ['/usr/local/lib'];},
+    'ia32': function() {return ['/usr/local/lib'];},
+    'x64': function() {return ['/usr/local/lib'];},
+    'arm': function() {return ['/usr/local/lib'];},
     'def': function() {return ['/usr/local/lib'];},
 };
 let defaultMacLibraryLocsToSearch = {
-    // 'ia32': function() {return ['/usr/local/lib'];},
-    // 'x64': function() {return ['/usr/local/lib'];},
+    'ia32': function() {return ['/usr/local/lib'];},
+    'x64': function() {return ['/usr/local/lib'];},
     'def': function() {return ['/usr/local/lib'];},
 };
 let defaultWindowsLibraryLocsToSearch = {


### PR DESCRIPTION
Using the package on Linux - ( Node 18, ES6 module) would get this error

TypeError: {(intermediate value)(intermediate value)(intermediate value)}[os][archQuery] is not a function
    at Object.<anonymous> (/home/gary/Desktop/Dev/xstate/node_modules/ljswitchboard-ljm_driver_constants/lib/driver_constants.js:688:17)

The issue was that the return values for defaultLinuxLibraryLocsToSearch and defaultMacLibraryLocsToSearch are commented.

Removing the comments removed the error 

exports.LJM_LIBRARY_SEARCH_PATHS now has the correct value.
